### PR TITLE
Fix passthrough copy bug

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -28,7 +28,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addLayoutAlias('default', 'default.liquid');
 
   eleventyConfig.addPassthroughCopy('src/fonts');
-  eleventyConfig.addPassthroughCopy('**/*.(png|jpg|jpeg|gif)');
+  eleventyConfig.addPassthroughCopy('src/**/*.(png|jpg|jpeg|gif)');
   eleventyConfig.addPassthroughCopy('src/js');
 
   eleventyConfig.addCollection('tagList', function (collection) {


### PR DESCRIPTION
I was having trouble with passthrough copy because I was watching the entire project, including the `_site` output directory. Oops. I'm now limiting the watch to the `src` directory.