### PR TITLE
Add unique id generation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,8 @@ const { DateTime } = require('luxon');
 const readingTime = require('reading-time');
 const EMPTY = require('./src/_data/empty');
 
+let id = 0;
+
 module.exports = function (eleventyConfig) {
   // merge all data arrays
   eleventyConfig.setDataDeepMerge(true);
@@ -65,6 +67,10 @@ module.exports = function (eleventyConfig) {
     return `<a class="c-tag" href="${urlify(
       tagUrl
     )}"><span class="o-visually-hidden">Posts tagged </span>${tag}</a>`;
+  });
+
+  eleventyConfig.addShortcode('uid', function () {
+    return String(id++);
   });
 
   return {

--- a/src/_includes/postslist.liquid
+++ b/src/_includes/postslist.liquid
@@ -26,8 +26,9 @@
         </time>
         {% endif %}
       </p>
-      <span id="taglist-label" hidden>Tags</span>
-      <ul class="c-tags o-cluster" aria-labelledby="taglist-label">
+      {% capture tagId %}taglist-label-{% uid %}{% endcapture %}
+      <span id="{{ tagId }}" hidden>Tags</span>
+      <ul class="c-tags o-cluster" aria-labelledby="{{ tagId }}">
         {% for tag in post.data.tags %} {% if collections.tagList contains tag
         %}<li>{% tagLink tag %}</li> {% endif
         %} {% endfor %}


### PR DESCRIPTION
This fixes the duplicate ID issue when multiple tag lists appear on the same page.