### PR TITLE
Adjust project scripts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "_site"
-  command = "npm install && DEBUG=* npm run build:prod"
+  command = "DEBUG=* npm run build"

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "My personal website",
   "main": "index.js",
   "scripts": {
-    "start": "npm run clean && npm run watch:ssg & npm run watch:css",
-    "build": "npm run clean && npm run build:ssg & npm run build:css",
-    "build:prod": "npm-run-all --parallel build:ssg build:css",
+    "start": "npm run watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf _site",
+    "build": "npm-run-all clean --parallel build:*",
     "build:css": "sass src/scss:_site/css",
     "build:ssg": "eleventy",
+    "watch": "npm-run-all clean --parallel watch:*",
     "watch:css": "npm run build:css -- --watch",
     "watch:ssg": "npm run build:ssg -- --serve --port=3000",
-    "debug:ssg": "DEBUG=Eleventy* npm run build:ssg"
+    "debug": "DEBUG=Eleventy* npm run build:ssg"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
After doing some digging, I found out that the ampersand pushes a task
to the background, allowing another task to be run on top of it. The
problem with this is there's no easy way of knowing when the background
task finishes, so if the foreground task finishes before, Netlify will
throw an error. npm-run-all fixes this, so I can go back to the standard
build script.