### PR TITLE
Fix code formatting

### DIFF
--- a/src/blog/how-to-get-your-pull-request-merged/index.md
+++ b/src/blog/how-to-get-your-pull-request-merged/index.md
@@ -38,7 +38,7 @@ If you can't find any standards, here's a great article on [how to write commit 
 
 And here's an example commit following these guidelines:
 
-```
+```plain
 Add new awesome feature
 
 Use this space for anything that needs further explanation. You can 
@@ -64,7 +64,7 @@ Pull requests should be kept short. If they can't be kept short, use atomic comm
 
 Let's imagine we need to add a new form to a project that uses existing logic. The commit history might look something like this:
 
-```
+```plain
 Reformat file to match standards
 Refactor variable names for readability
 Refactor form submission to extract logic

--- a/src/blog/notes-to-my-younger-self-regarding-accessibility/index.md
+++ b/src/blog/notes-to-my-younger-self-regarding-accessibility/index.md
@@ -65,7 +65,7 @@ Also, I don't know what you're up to with all those `aria` attributes, but I kno
 
 Remember when you coded up that swanky dropdown menu that faded in and out? Yeah, that was slick! Remember the CSS you used?
 
-```sass
+```scss
 .dropdown-panel {
 	opacity: 0;
 	transition: opacity 200ms;

--- a/src/blog/share-variables-between-javascript-and-css/index.md
+++ b/src/blog/share-variables-between-javascript-and-css/index.md
@@ -18,7 +18,7 @@ The answer is to create a single source of truth by sharing values between the J
 
 ICSS is a low-level specification that's mainly for loader authors. It describes how to treat CSS modules as JavaScript dependencies and introduces the `:export` directive to act as a way to export defined values. Coupled with Sass variables, it allows you to export theme values:
 
-```sass
+```scss
 // colors.module.scss
 // assuming this is within Create React App; the `.module` lets CRA know
 // this is a CSS Module
@@ -74,7 +74,7 @@ module.exports = {
 
 CSS Modules also offers [the `@value` directive](https://github.com/css-modules/postcss-modules-values), which explicitly defines module values. `@value` can also be used to import values from other CSS modules. It's a catchall solution for passing values to and from CSS modules to anywhere.
 
-```sass
+```scss
 // breakpoints.module.css
 
 @value larry: (max-width: 599px);

--- a/src/blog/the-curious-case-of-flexbox-gap-and-safari/index.md
+++ b/src/blog/the-curious-case-of-flexbox-gap-and-safari/index.md
@@ -9,7 +9,7 @@ tags:
 
 The `gap` property was first introduced to add inner grid spacing but was extended in the spec to work with flexbox. With one line of code, you can replace something like this:
 
-```sass
+```scss
 .flex-container {
   display: flex;
   flex-wrap: wrap;
@@ -23,7 +23,7 @@ The `gap` property was first introduced to add inner grid spacing but was extend
 
 with this:
 
-```sass
+```scss
 .flex-container {
   display: flex;
   flex-wrap: wrap;
@@ -34,7 +34,7 @@ with this:
 
 That's nice, but Safari doesn't support `gap` in flexbox just yet. Normally I'd just reach for `@supports`:
 
-```sass
+```scss
 .flex-container {
   display: flex;
   flex-wrap: wrap;

--- a/src/blog/what-is-your-code-communicating/index.md
+++ b/src/blog/what-is-your-code-communicating/index.md
@@ -17,7 +17,7 @@ Let's look at an example in [Sass](https://sass-lang.com). If you're unfamiliar 
 
 Imagine you come across this style in a code review:
 
-```sass
+```scss
 .subheading-2 {
   font-size: 1.5rem;
   font-weight: bold;
@@ -34,7 +34,7 @@ You can probably figure out what that line is doing, but it's an unnecessary spe
 
 Let's try making that `margin-top` a bit more readable:
 
-```sass
+```scss
 .subheading-2 {
   font-size: 1.5rem;
   font-weight: bold;
@@ -47,7 +47,7 @@ You are less likely to get any questions about that. But I'm still bothered by o
 
 What I want to do is communicate that, at the effective font size of `24px` (`1.5rem`), the `margin-top` should be `20px`. You might be tempted to communicate this in a comment, which is easy to do in Sass:
 
-```sass
+```scss
 .subheading-2 {
   font-size: 1.5rem;
   font-weight: bold;
@@ -65,7 +65,7 @@ If you find yourself writing comments like this, a good rule of thumb is to use 
 
 Let's incorporate our new `em` function into our style:
 
-```sass
+```scss
 .subheading-2 {
   font-size: rem($px: 24);
   font-weight: bold;


### PR DESCRIPTION
Setting plain on all text code blocks and replacing the unsupported `sass` code block with `scss`. Soon I'll bake in a bunch of support by moving Prism to the build step.